### PR TITLE
Fixed problems with gpsd build.

### DIFF
--- a/sbc-platform/README.MD
+++ b/sbc-platform/README.MD
@@ -103,7 +103,8 @@ How to install old version of gpsd library from source:
  
 ```
 $ cd ~/src/GL-SMARTCITY/sbc-platform/lib/gpsd
-$ git checkout -b gpsd_2_95 9cd56c55 
+$ git checkout -b gpsd_2_95 9cd56c55
+$ export PATH="/usr/bin:$PATH" 
 $ ./autogen.sh && ./configure
 $ make -j"$(nproc)"
 $ sudo make install && sudo ldconfig -v


### PR DESCRIPTION
Added `<sys/sysmacros.h>` to _gpsd/_**serial.c** file to set reference for 'major' function.

Added `export PATH="/usr/bin:$PATH"` to **README.md** to solve the problem with python dependencies.